### PR TITLE
Updated README.md for repo name change

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ You can use the events above to do your own downloading of images and what not. 
 You can search for this addon in the `Tools > Addons` section of the Statamic control panel and click **install**, or run the following command from your project root:
 
 ``` bash
-composer require RadPack/wp-import
+composer require statamic-rad-pack/wp-import
 ```
 
 ## How to Use


### PR DESCRIPTION
Changed to match the repo name statamic-rad-pack/wp-import